### PR TITLE
Fix Documentation link in top-level menu

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -17,8 +17,6 @@ side:
         url: "/docs/benchmarks/"
       - title: "Hardware"
         url: "/docs/hardware/"
-      - title: "Musashi"
-        url: "/docs/musashi/"
       - title: "Emu68"
         url: "/docs/emu68/"
   - title: "Tutorials"

--- a/_pages/docs.md
+++ b/_pages/docs.md
@@ -1,0 +1,12 @@
+---
+title: "Documentation"
+permalink: /docs/
+layout: posts
+author_profile: false
+---
+
+*   [Compatibility](compatibility)
+*   [Performance](benchmarks)
+*   [Hardware](hardware)
+*   [Emu68](emu68)
+


### PR DESCRIPTION
I noticed the top-level "Documentation" link was a 404. This fixes that by adding a page for /docs/.

The content is a copy of the menu structure from navigation corresponding to Documentation. However, I removed
Musashi from both, as docs/musashi/ does not exist.